### PR TITLE
refactor(nats): isolate DLQ reliability boundaries

### DIFF
--- a/configs/prometheus-alerts.yml
+++ b/configs/prometheus-alerts.yml
@@ -187,7 +187,7 @@ groups:
 
             Check NATS JetStream connectivity and publisher logs.
 
-      # Warning: DLQ publish failures (messages lost)
+      # Warning: DLQ publish failures (the original message is retained)
       - alert: DLQPublishFailures
         expr: rate(caatsm_dlq_publish_failures_total[5m]) > 0
         for: 2m
@@ -197,13 +197,25 @@ groups:
         annotations:
           summary: "DLQ publish failures detected"
           description: |
-            Failed messages cannot be published to DLQ - messages may be lost!
+            Failed messages cannot be published to DLQ. The original message is retained for recovery.
             Failure rate: {{ $value | humanize }} msgs/sec
 
             Stream: {{ $labels.stream }}
             Consumer: {{ $labels.consumer }}
 
             Check DLQ subject configuration and NATS JetStream health.
+
+      - alert: DLQTerminalFailures
+        expr: increase(caatsm_dlq_terminal_failures_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: dlq
+        annotations:
+          summary: "DLQ terminal failure requires manual recovery"
+          description: |
+            A message exhausted its delivery limit and could not be routed to DLQ.
+            Recover the retained message from the source stream after restoring DLQ health.
 
   - name: caatsm_aftn_validation_details
     interval: 1m

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -28,6 +28,12 @@ The service exposes Prometheus metrics via the monitoring HTTP server (default `
 - `caatsm_dlq_publish_failures_total{stream,consumer}`  
   Count of failures when attempting to publish messages to the DLQ.
 
+- `caatsm_dlq_terminal_failures_total{stream,consumer}`
+  Count of messages retained in the source stream after DLQ routing cannot be retried.
+
+- `caatsm_dlq_disabled_messages_total{stream,consumer}`
+  Count of failed messages retained because DLQ routing is disabled.
+
 - `caatsm_publish_failures_total{category}`  
   Count of general publish failures (not DLQ-specific), labelled by message category.
 
@@ -281,4 +287,3 @@ Logging is done with Zap. The `internal/infra/log` package standardises fields v
   - `fatal` – programming errors, schema mismatches, or configuration issues requiring operator attention.
 
 Handler and consumer logs should always be emitted through `WithMessageContext` to ensure these fields are present where applicable.
-

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -12,7 +12,7 @@ enabled = true
 subject = "caatsm.dlq"
 ```
 
-- When `dlq.enabled` is `true` and `dlq.subject` is non-empty, **permanent** failures are routed to the DLQ subject.  
+- When `dlq.enabled` is `true` and `dlq.subject` is non-empty, the service creates a dedicated `<stream>_DLQ` JetStream stream with Limits retention. Its capacity and retention are independent of the business WorkQueue stream.
 - A permanent failure is indicated by wrapping an error with `app.Permanent` and is treated as a **poison message**.
 
 Behaviour:
@@ -23,14 +23,13 @@ Behaviour:
      - `subject`, `stream`, `consumer`
      - `error` (stringified cause)
      - `received_at` (DLQ event time)
-     - `body` (raw message body)
-     - `transport_msg_id` (NATS `Nats-Msg-Id` header, if set)
-     - `nats_sequence` (JetStream stream sequence number)
-     - `deliveries` (JetStream delivery count)
-     - `reply` (NATS reply subject, if present)
-     - `headers` (NATS message headers, if any)
+     - `schema_version`, `message_id` (the `Nats-Msg-Id` header, or the stable source stream sequence)
+     - `stream_sequence`, `consumer_sequence`, and `delivery_count`
+     - `error`, `headers`, and `body_base64` (lossless message bytes)
    - The payload is published to `dlq.subject` using JetStream.  
-   - The original message is **ACKed**, so it will not be redelivered.
+   - The original message is **ACKed only after** JetStream confirms the DLQ publish.
+   - If the DLQ publish fails before `max_deliver` is exhausted, the original is delayed with NAK for another attempt. At `max_deliver`, it remains unacknowledged in the source stream and increments `caatsm_dlq_terminal_failures_total`; recover it manually according to the runbook.
+   - With DLQ disabled, failed messages are retained in the source stream and increment `caatsm_dlq_disabled_messages_total`; operators must either enable DLQ or recover them manually.
 
 The DLQ subject should be consumed by an offline repair/analysis tool or operational dashboard that can:
 
@@ -105,7 +104,7 @@ Recommended pattern:
 
 - Keep `max_deliver` modest (e.g. 5).  
 - Use a backoff array such as `[5s, 30s, 2m]`.  
-- Treat messages that still fail after `max_deliver` as candidates for DLQ, via the permanent error/poison message path where applicable.
+- Route a message that reaches `max_deliver` to DLQ. If that publish fails, JetStream will not automatically retry it; use the terminal-failure alert and recover the retained source message manually.
 
 ### JetStream Availability and Auto-Recovery (Dev vs Prod)
 
@@ -149,4 +148,3 @@ Dashboards should combine:
 - Message rates, error rates, and DLQ rates.  
 - NATS consumer statistics (pending, redelivered, ack_pending).  
 - DB health indicators (latency, error counts, connection usage).
-

--- a/internal/infra/metrics/metrics.go
+++ b/internal/infra/metrics/metrics.go
@@ -17,23 +17,25 @@ import (
 // documentation aligned with the implementation.
 const (
 	// Metric names.
-	MetricProcessedTotal        = "caatsm_processed_total"
-	MetricFailuresTotal         = "caatsm_failures_total"
-	MetricParseLatencySeconds   = "caatsm_parse_latency_seconds"
-	MetricMessagesTotal         = "caatsm_messages_total"
-	MetricHandleLatencySeconds  = "caatsm_handle_latency_seconds"
-	MetricRetriesTotal          = "caatsm_retries_total"
-	MetricJSAPICallsTotal       = "caatsm_js_api_calls_total"
-	MetricDBQueriesTotal        = "caatsm_db_queries_total"
-	MetricDBQueryLatencySeconds = "caatsm_db_query_latency_seconds"
-	MetricDLQMessagesTotal            = "caatsm_dlq_messages_total"
-	MetricDLQPublishFailures          = "caatsm_dlq_publish_failures_total"
-	MetricPublishFailuresTotal        = "caatsm_publish_failures_total"
-	MetricNATSConsumerPending         = "caatsm_nats_consumer_pending_messages"
-	MetricAFTNValidationErrorsTotal   = "caatsm_aftn_validation_errors_total"
-	MetricMessageGapSeconds           = "caatsm_message_gap_seconds"
-	MetricMessageSequenceGapTotal     = "caatsm_message_sequence_gap_total"
-	MetricConsumerHealthy             = "caatsm_consumer_healthy"
+	MetricProcessedTotal            = "caatsm_processed_total"
+	MetricFailuresTotal             = "caatsm_failures_total"
+	MetricParseLatencySeconds       = "caatsm_parse_latency_seconds"
+	MetricMessagesTotal             = "caatsm_messages_total"
+	MetricHandleLatencySeconds      = "caatsm_handle_latency_seconds"
+	MetricRetriesTotal              = "caatsm_retries_total"
+	MetricJSAPICallsTotal           = "caatsm_js_api_calls_total"
+	MetricDBQueriesTotal            = "caatsm_db_queries_total"
+	MetricDBQueryLatencySeconds     = "caatsm_db_query_latency_seconds"
+	MetricDLQMessagesTotal          = "caatsm_dlq_messages_total"
+	MetricDLQPublishFailures        = "caatsm_dlq_publish_failures_total"
+	MetricDLQTerminalFailures       = "caatsm_dlq_terminal_failures_total"
+	MetricDLQDisabled               = "caatsm_dlq_disabled_messages_total"
+	MetricPublishFailuresTotal      = "caatsm_publish_failures_total"
+	MetricNATSConsumerPending       = "caatsm_nats_consumer_pending_messages"
+	MetricAFTNValidationErrorsTotal = "caatsm_aftn_validation_errors_total"
+	MetricMessageGapSeconds         = "caatsm_message_gap_seconds"
+	MetricMessageSequenceGapTotal   = "caatsm_message_sequence_gap_total"
+	MetricConsumerHealthy           = "caatsm_consumer_healthy"
 
 	// Common label keys.
 	LabelStatus    = "status"
@@ -74,12 +76,14 @@ var (
 	parseLatency     *prometheus.HistogramVec
 
 	// Message handling metrics (per stream / consumer).
-	messagesTotal      *prometheus.CounterVec
-	handleLatency      *prometheus.HistogramVec
-	retriesTotal       *prometheus.CounterVec
-	jsAPICallsTotal    *prometheus.CounterVec
-	dlqMessagesTotal   *prometheus.CounterVec
-	dlqPublishFailures *prometheus.CounterVec
+	messagesTotal        *prometheus.CounterVec
+	handleLatency        *prometheus.HistogramVec
+	retriesTotal         *prometheus.CounterVec
+	jsAPICallsTotal      *prometheus.CounterVec
+	dlqMessagesTotal     *prometheus.CounterVec
+	dlqPublishFailures   *prometheus.CounterVec
+	dlqTerminalFailures  *prometheus.CounterVec
+	dlqDisabled          *prometheus.CounterVec
 	publishFailuresTotal *prometheus.CounterVec
 
 	// Database metrics.
@@ -142,6 +146,14 @@ func initCollectors() {
 		Name: MetricDLQPublishFailures,
 		Help: "Total number of failures when publishing to the DLQ, labelled by stream and consumer.",
 	}, []string{LabelStream, LabelConsumer})
+	dlqTerminalFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: MetricDLQTerminalFailures,
+		Help: "Total number of failed messages retained after DLQ recovery is exhausted.",
+	}, []string{LabelStream, LabelConsumer})
+	dlqDisabled = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: MetricDLQDisabled,
+		Help: "Total number of failed messages retained because DLQ routing is disabled.",
+	}, []string{LabelStream, LabelConsumer})
 
 	publishFailuresTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: MetricPublishFailuresTotal,
@@ -201,6 +213,8 @@ func initCollectors() {
 		jsAPICallsTotal,
 		dlqMessagesTotal,
 		dlqPublishFailures,
+		dlqTerminalFailures,
+		dlqDisabled,
 		publishFailuresTotal,
 		dbQueriesTotal,
 		dbQueryLatency,
@@ -267,6 +281,16 @@ func RecordDLQPublishFailure(stream, consumer string) {
 	dlqPublishFailures.WithLabelValues(labelValue(stream), labelValue(consumer)).Inc()
 }
 
+func RecordDLQTerminalFailure(stream, consumer string) {
+	ensureCollectors()
+	dlqTerminalFailures.WithLabelValues(labelValue(stream), labelValue(consumer)).Inc()
+}
+
+func RecordDLQDisabled(stream, consumer string) {
+	ensureCollectors()
+	dlqDisabled.WithLabelValues(labelValue(stream), labelValue(consumer)).Inc()
+}
+
 // RecordPublishFailure increments the publish failure counter for the given category.
 // This tracks general publish failures (not DLQ-specific).
 func RecordPublishFailure(category string) {
@@ -296,11 +320,11 @@ func RecordJSAPICall(operation string) {
 // JetStream consumer as a gauge, enabling backlog / lag alerts.
 func RecordNATSConsumerPending(stream, consumer string, pending uint64) {
 	ensureCollectors()
-	
+
 	// Validate inputs to ensure metric is recorded correctly
 	streamLabel := labelValue(stream)
 	consumerLabel := labelValue(consumer)
-	
+
 	// Ensure metric is always set, even with empty labels (will be "unknown")
 	if streamLabel == "" {
 		streamLabel = "unknown"
@@ -308,7 +332,7 @@ func RecordNATSConsumerPending(stream, consumer string, pending uint64) {
 	if consumerLabel == "" {
 		consumerLabel = "unknown"
 	}
-	
+
 	// Set the metric value
 	natsConsumerPending.WithLabelValues(streamLabel, consumerLabel).Set(float64(pending))
 }

--- a/internal/infra/metrics/metrics_test.go
+++ b/internal/infra/metrics/metrics_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Metrics", func() {
 			RecordRetry("stream1", "consumer1", RetryReasonProcessorError)
 			RecordDLQMessage("stream1", "consumer1")
 			RecordDLQPublishFailure("stream1", "consumer1")
+			RecordDLQTerminalFailure("stream1", "consumer1")
+			RecordDLQDisabled("stream1", "consumer1")
 			RecordPublishFailure("flightPlan")
 			RecordDBQuery("insert_one", DBResultOK, 10*time.Millisecond)
 			RecordJSAPICall("publish")
@@ -66,6 +68,8 @@ var _ = Describe("Metrics", func() {
 
 			Expect(testutil.ToFloat64(dlqMessagesTotal.WithLabelValues("stream1", "consumer1"))).To(BeNumerically("==", 1))
 			Expect(testutil.ToFloat64(dlqPublishFailures.WithLabelValues("stream1", "consumer1"))).To(BeNumerically("==", 1))
+			Expect(testutil.ToFloat64(dlqTerminalFailures.WithLabelValues("stream1", "consumer1"))).To(BeNumerically("==", 1))
+			Expect(testutil.ToFloat64(dlqDisabled.WithLabelValues("stream1", "consumer1"))).To(BeNumerically("==", 1))
 
 			Expect(testutil.ToFloat64(publishFailuresTotal.WithLabelValues("flightplan"))).To(BeNumerically("==", 1))
 
@@ -97,6 +101,8 @@ func resetMetricsForTest() {
 	jsAPICallsTotal = nil
 	dlqMessagesTotal = nil
 	dlqPublishFailures = nil
+	dlqTerminalFailures = nil
+	dlqDisabled = nil
 	publishFailuresTotal = nil
 	dbQueriesTotal = nil
 	dbQueryLatency = nil

--- a/internal/infra/nats/consumer.go
+++ b/internal/infra/nats/consumer.go
@@ -45,6 +45,13 @@ type Consumer struct {
 	consecutiveErrors int
 }
 
+type acknowledgmentMessage interface {
+	Ack(...nats.AckOpt) error
+	Nak(...nats.AckOpt) error
+	NakWithDelay(time.Duration, ...nats.AckOpt) error
+	Metadata() (*nats.MsgMetadata, error)
+}
+
 // ProvideConsumer initializes a NATS consumer, ensuring infrastructure exists.
 func ProvideConsumer(
 	conn *nats.Conn,
@@ -261,11 +268,15 @@ func (c *Consumer) routeToDLQOrRetain(ctx context.Context, msg *nats.Msg, msgID 
 		return
 	}
 
-	if err := c.dlqHandler.RouteToDLQ(ctx, msg, cause); err != nil {
+	c.completeDLQRouting(ctx, msg, msgID, reason, c.dlqHandler.RouteToDLQ(ctx, msg, cause))
+}
+
+func (c *Consumer) completeDLQRouting(ctx context.Context, msg acknowledgmentMessage, msgID, reason string, routeErr error) {
+	if routeErr != nil {
 		c.logger.Error("DLQ publish failed; retaining original message",
 			zap.String("msg_id", msgID),
 			zap.String("reason", reason),
-			zap.Error(err),
+			zap.Error(routeErr),
 		)
 		c.retainAfterDLQFailure(ctx, msg, msgID, reason)
 		return
@@ -279,7 +290,7 @@ func (c *Consumer) routeToDLQOrRetain(ctx context.Context, msg *nats.Msg, msgID 
 	}
 }
 
-func (c *Consumer) retainAfterDLQFailure(ctx context.Context, msg *nats.Msg, msgID, reason string) {
+func (c *Consumer) retainAfterDLQFailure(ctx context.Context, msg acknowledgmentMessage, msgID, reason string) {
 	if c.maxDeliverReached(msg) {
 		c.logger.Error("DLQ terminal failure; original message retained for manual recovery",
 			zap.String("msg_id", msgID),
@@ -296,7 +307,7 @@ func (c *Consumer) retainAfterDLQFailure(ctx context.Context, msg *nats.Msg, msg
 	}
 }
 
-func (c *Consumer) maxDeliverReached(msg *nats.Msg) bool {
+func (c *Consumer) maxDeliverReached(msg acknowledgmentMessage) bool {
 	maxDeliver := c.cfg.NATS.ConsumerRules.MaxDeliver
 	if maxDeliver <= 0 {
 		return false
@@ -306,7 +317,7 @@ func (c *Consumer) maxDeliverReached(msg *nats.Msg) bool {
 }
 
 // nakWithBackoff calculates the appropriate NAK delay based on delivery attempts.
-func (c *Consumer) nakWithBackoff(msg *nats.Msg) error {
+func (c *Consumer) nakWithBackoff(msg acknowledgmentMessage) error {
 	if len(c.backoff) == 0 {
 		return msg.Nak()
 	}

--- a/internal/infra/nats/consumer.go
+++ b/internal/infra/nats/consumer.go
@@ -117,7 +117,11 @@ func (c *Consumer) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to subscribe: %w", err)
 	}
-	defer sub.Unsubscribe()
+	defer func() {
+		if err := sub.Unsubscribe(); err != nil {
+			c.logger.Warn("failed to unsubscribe consumer", zap.Error(err))
+		}
+	}()
 
 	// Initial metric recording
 	if info, err := c.js.ConsumerInfo(c.streamName, c.consumerName); err == nil {
@@ -179,7 +183,7 @@ func (c *Consumer) processMsg(ctx context.Context, msg *nats.Msg) {
 	defer span.End()
 
 	msgID := c.resolveMsgID(msg)
-	
+
 	// Add metadata to span/logger
 	span.SetAttributes(
 		attribute.String("messaging.system", "nats"),
@@ -189,7 +193,7 @@ func (c *Consumer) processMsg(ctx context.Context, msg *nats.Msg) {
 
 	// Execute Application Logic
 	err := c.processor.Handle(ctx, msg.Data, msgID)
-	
+
 	// Handle Result
 	if err != nil {
 		c.handleError(ctx, msg, msgID, err)
@@ -218,44 +222,21 @@ func (c *Consumer) handleError(ctx context.Context, msg *nats.Msg, msgID string,
 	)
 
 	if isPermanent {
-		// Poison message: Route to DLQ -> Ack only if DLQ succeeds or DLQ is disabled
 		c.consecutiveErrors = 0
-		if c.dlqHandler != nil {
-			if dlqErr := c.dlqHandler.RouteToDLQ(ctx, msg, err); dlqErr != nil {
-				c.logger.Error("DLQ publish failed, NAKing original message for redelivery",
-					zap.String("msg_id", msgID),
-					zap.Error(dlqErr),
-				)
-				c.telemetry.RecordDLQPublishFailure(ctx, c.streamName, c.consumerName)
-				_ = msg.Nak()
-				return
-			}
-		}
-		_ = msg.Ack()
+		c.routeToDLQOrRetain(ctx, msg, msgID, err, "permanent")
 		return
 	}
 
 	// Transient error: check if MaxDeliver exhausted
 	meta, metaErr := msg.Metadata()
-	if metaErr == nil && int(meta.NumDelivered) >= c.cfg.NATS.ConsumerRules.MaxDeliver {
+	if c.cfg.NATS.ConsumerRules.MaxDeliver > 0 && metaErr == nil && int(meta.NumDelivered) >= c.cfg.NATS.ConsumerRules.MaxDeliver {
 		c.logger.Error("Transient error exhausted max deliveries, routing to DLQ",
 			zap.String("msg_id", msgID),
 			zap.Uint64("delivered", meta.NumDelivered),
 			zap.Int("max_deliver", c.cfg.NATS.ConsumerRules.MaxDeliver),
 		)
 		c.consecutiveErrors = 0
-		if c.dlqHandler != nil {
-			if dlqErr := c.dlqHandler.RouteToDLQ(ctx, msg, err); dlqErr != nil {
-				c.logger.Error("DLQ publish failed for exhausted message, NAKing for redelivery",
-					zap.String("msg_id", msgID),
-					zap.Error(dlqErr),
-				)
-				c.telemetry.RecordDLQPublishFailure(ctx, c.streamName, c.consumerName)
-				_ = msg.Nak()
-				return
-			}
-		}
-		_ = msg.Ack()
+		c.routeToDLQOrRetain(ctx, msg, msgID, err, "max_deliver_exhausted")
 		return
 	}
 
@@ -263,6 +244,65 @@ func (c *Consumer) handleError(ctx context.Context, msg *nats.Msg, msgID string,
 	c.consecutiveErrors++
 	c.applyBackpressure(ctx)
 	_ = c.nakWithBackoff(msg)
+}
+
+// routeToDLQOrRetain acknowledges the original message only after its DLQ copy
+// is durably accepted. Otherwise the original remains available for retry or
+// manual recovery.
+func (c *Consumer) routeToDLQOrRetain(ctx context.Context, msg *nats.Msg, msgID string, cause error, reason string) {
+	if c.dlqHandler == nil {
+		c.logger.Warn("DLQ is disabled; retaining failed message in the source stream",
+			zap.String("msg_id", msgID),
+			zap.String("reason", reason),
+			zap.Error(cause),
+		)
+		c.telemetry.RecordDLQDisabled(ctx, c.streamName, c.consumerName)
+		c.retainAfterDLQFailure(ctx, msg, msgID, reason)
+		return
+	}
+
+	if err := c.dlqHandler.RouteToDLQ(ctx, msg, cause); err != nil {
+		c.logger.Error("DLQ publish failed; retaining original message",
+			zap.String("msg_id", msgID),
+			zap.String("reason", reason),
+			zap.Error(err),
+		)
+		c.retainAfterDLQFailure(ctx, msg, msgID, reason)
+		return
+	}
+
+	if err := msg.Ack(); err != nil {
+		c.logger.Warn("failed to ACK original message after DLQ publish",
+			zap.String("msg_id", msgID),
+			zap.Error(err),
+		)
+	}
+}
+
+func (c *Consumer) retainAfterDLQFailure(ctx context.Context, msg *nats.Msg, msgID, reason string) {
+	if c.maxDeliverReached(msg) {
+		c.logger.Error("DLQ terminal failure; original message retained for manual recovery",
+			zap.String("msg_id", msgID),
+			zap.String("reason", reason),
+		)
+		c.telemetry.RecordDLQTerminalFailure(ctx, c.streamName, c.consumerName)
+		return
+	}
+	if err := c.nakWithBackoff(msg); err != nil {
+		c.logger.Warn("failed to NAK original message after DLQ publish failure",
+			zap.String("msg_id", msgID),
+			zap.Error(err),
+		)
+	}
+}
+
+func (c *Consumer) maxDeliverReached(msg *nats.Msg) bool {
+	maxDeliver := c.cfg.NATS.ConsumerRules.MaxDeliver
+	if maxDeliver <= 0 {
+		return false
+	}
+	meta, err := msg.Metadata()
+	return err == nil && int(meta.NumDelivered) >= maxDeliver
 }
 
 // nakWithBackoff calculates the appropriate NAK delay based on delivery attempts.
@@ -274,7 +314,7 @@ func (c *Consumer) nakWithBackoff(msg *nats.Msg) error {
 	if err != nil {
 		return msg.Nak()
 	}
-	
+
 	// attempt is 1-based, index is 0-based
 	attempt := int(meta.NumDelivered)
 	index := attempt - 1
@@ -283,7 +323,7 @@ func (c *Consumer) nakWithBackoff(msg *nats.Msg) error {
 	} else if index < 0 {
 		index = 0
 	}
-	
+
 	return msg.NakWithDelay(c.backoff[index])
 }
 
@@ -296,7 +336,7 @@ func (c *Consumer) applyBackpressure(ctx context.Context) {
 	if delay > 5*time.Second {
 		delay = 5 * time.Second
 	}
-	
+
 	select {
 	case <-time.After(delay):
 	case <-ctx.Done():
@@ -310,19 +350,15 @@ func (c *Consumer) ensureInfrastructure() error {
 	if c.cfg.Publisher.Topic != "" {
 		subjects = append(subjects, c.cfg.Publisher.Topic)
 	}
-	if c.cfg.DLQ.Enabled && c.cfg.DLQ.Subject != "" {
-		subjects = append(subjects, c.cfg.DLQ.Subject)
-	}
-	
 	streamCfg := &nats.StreamConfig{
-		Name:     c.streamName,
-		Subjects: dedupeSubjects(subjects),
+		Name:      c.streamName,
+		Subjects:  dedupeSubjects(subjects),
 		Retention: nats.WorkQueuePolicy, // Defaulting to WorkQueue for queues
-		MaxMsgs:  c.cfg.NATS.StreamLimits.MaxMsgs,
-		MaxBytes: c.cfg.NATS.StreamLimits.MaxBytes,
-		MaxAge:   c.cfg.NATS.StreamLimits.MaxAge,
-		Replicas: c.cfg.NATS.StreamLimits.Replicas,
-		Storage:  nats.FileStorage,
+		MaxMsgs:   c.cfg.NATS.StreamLimits.MaxMsgs,
+		MaxBytes:  c.cfg.NATS.StreamLimits.MaxBytes,
+		MaxAge:    c.cfg.NATS.StreamLimits.MaxAge,
+		Replicas:  c.cfg.NATS.StreamLimits.Replicas,
+		Storage:   nats.FileStorage,
 	}
 	if c.cfg.NATS.StreamLimits.Discard == "new" {
 		streamCfg.Discard = nats.DiscardNew
@@ -331,9 +367,11 @@ func (c *Consumer) ensureInfrastructure() error {
 		streamCfg.Storage = nats.MemoryStorage
 	}
 
-	// Idempotent add/update
-	if _, err := c.js.AddStream(streamCfg); err != nil {
+	if err := c.ensureStream(streamCfg); err != nil {
 		return fmt.Errorf("ensure stream: %w", err)
+	}
+	if err := c.ensureDLQStream(); err != nil {
+		return err
 	}
 
 	// 2. Ensure Consumer
@@ -349,13 +387,50 @@ func (c *Consumer) ensureInfrastructure() error {
 	if c.cfg.NATS.ConsumerRules.ReplayPolicy == "original" {
 		consumerCfg.ReplayPolicy = nats.ReplayOriginalPolicy
 	}
-	
+
 	// Idempotent add/update
 	if _, err := c.js.AddConsumer(c.streamName, consumerCfg); err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
 
 	return nil
+}
+
+func (c *Consumer) ensureDLQStream() error {
+	if !c.cfg.DLQ.Enabled {
+		return nil
+	}
+
+	streamCfg := &nats.StreamConfig{
+		Name:      c.streamName + "_DLQ",
+		Subjects:  []string{c.cfg.DLQ.Subject},
+		Retention: nats.LimitsPolicy,
+		Replicas:  c.cfg.NATS.StreamLimits.Replicas,
+		Storage:   nats.FileStorage,
+	}
+	if streamCfg.Replicas == 0 {
+		streamCfg.Replicas = 1
+	}
+	if c.cfg.NATS.StreamLimits.Storage == "memory" {
+		streamCfg.Storage = nats.MemoryStorage
+	}
+	if err := c.ensureStream(streamCfg); err != nil {
+		return fmt.Errorf("ensure DLQ stream %q: %w", streamCfg.Name, err)
+	}
+	return nil
+}
+
+func (c *Consumer) ensureStream(streamCfg *nats.StreamConfig) error {
+	_, err := c.js.StreamInfo(streamCfg.Name)
+	if err == nil {
+		_, err = c.js.UpdateStream(streamCfg)
+		return err
+	}
+	if !isJetStreamResourceNotFound(err) {
+		return err
+	}
+	_, err = c.js.AddStream(streamCfg)
+	return err
 }
 
 // resolveMsgID extracts the ID from headers or metadata.

--- a/internal/infra/nats/consumer_test.go
+++ b/internal/infra/nats/consumer_test.go
@@ -1,14 +1,48 @@
 package nats
 
 import (
+	"caatsm/internal/infra/config"
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
 )
+
+type lifecycleMessage struct {
+	metadata *nats.MsgMetadata
+	ackCount int
+	nakCount int
+	delay    time.Duration
+}
+
+func (m *lifecycleMessage) Ack(...nats.AckOpt) error { m.ackCount++; return nil }
+func (m *lifecycleMessage) Nak(...nats.AckOpt) error { m.nakCount++; return nil }
+func (m *lifecycleMessage) NakWithDelay(delay time.Duration, _ ...nats.AckOpt) error {
+	m.nakCount++
+	m.delay = delay
+	return nil
+}
+func (m *lifecycleMessage) Metadata() (*nats.MsgMetadata, error) { return m.metadata, nil }
+
+func testConsumer(rec *mockTelemetryRecorder) *Consumer {
+	return &Consumer{
+		cfg: &config.Config{NATS: config.NATSConfig{ConsumerRules: config.ConsumerRulesConfig{
+			MaxDeliver: 3,
+			Backoff:    []time.Duration{time.Second},
+		}}},
+		logger:       zap.NewNop(),
+		telemetry:    rec,
+		streamName:   "TEST",
+		consumerName: "consumer",
+		backoff:      []time.Duration{time.Second},
+	}
+}
 
 func TestNATS(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -43,6 +77,41 @@ var _ = Describe("Consumer helpers", func() {
 		It("maps replay policy to instant by default", func() {
 			Expect(mapReplayPolicy("original")).To(Equal(nats.ReplayOriginalPolicy))
 			Expect(mapReplayPolicy("")).To(Equal(nats.ReplayInstantPolicy))
+		})
+	})
+
+	Describe("DLQ terminal handling", func() {
+		It("ACKs only after a successful DLQ publish", func() {
+			consumer := testConsumer(&mockTelemetryRecorder{})
+			msg := &lifecycleMessage{metadata: &nats.MsgMetadata{NumDelivered: 1}}
+
+			consumer.completeDLQRouting(context.Background(), msg, "id", "permanent", nil)
+
+			Expect(msg.ackCount).To(Equal(1))
+			Expect(msg.nakCount).To(Equal(0))
+		})
+
+		It("delays NAK when DLQ publish fails before MaxDeliver", func() {
+			consumer := testConsumer(&mockTelemetryRecorder{})
+			msg := &lifecycleMessage{metadata: &nats.MsgMetadata{NumDelivered: 2}}
+
+			consumer.completeDLQRouting(context.Background(), msg, "id", "permanent", errors.New("DLQ unavailable"))
+
+			Expect(msg.ackCount).To(Equal(0))
+			Expect(msg.nakCount).To(Equal(1))
+			Expect(msg.delay).To(Equal(time.Second))
+		})
+
+		It("retains the original message and records a terminal failure at MaxDeliver", func() {
+			recorder := &mockTelemetryRecorder{}
+			consumer := testConsumer(recorder)
+			msg := &lifecycleMessage{metadata: &nats.MsgMetadata{NumDelivered: 3}}
+
+			consumer.completeDLQRouting(context.Background(), msg, "id", "max_deliver_exhausted", errors.New("DLQ unavailable"))
+
+			Expect(msg.ackCount).To(Equal(0))
+			Expect(msg.nakCount).To(Equal(0))
+			Expect(recorder.dlqTerminalFailures).To(Equal(1))
 		})
 	})
 })

--- a/internal/infra/nats/dlq_handler.go
+++ b/internal/infra/nats/dlq_handler.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"caatsm/internal/infra/telemetry"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -15,13 +16,11 @@ import (
 // making it easy to mock in tests without requiring the full JetStreamContext.
 type dlqPublisher interface {
 	Publish(subj string, data []byte, opts ...nats.PubOpt) (*nats.PubAck, error)
-	StreamNameBySubject(subj string, opts ...nats.JSOpt) (string, error)
 }
 
-// DLQHandler defines the interface for dead letter queue operations
+// DLQHandler defines the DLQ operation used by the consumer.
 type DLQHandler interface {
 	RouteToDLQ(ctx context.Context, msg *nats.Msg, cause error) error
-	ValidateDLQ() error
 }
 
 // defaultDLQHandler implements DLQHandler interface
@@ -34,38 +33,44 @@ type defaultDLQHandler struct {
 	telemetry    telemetry.Recorder
 }
 
+type dlqPayload struct {
+	SchemaVersion    string      `json:"schema_version"`
+	MessageID        string      `json:"message_id"`
+	Subject          string      `json:"subject"`
+	Stream           string      `json:"stream"`
+	Consumer         string      `json:"consumer"`
+	StreamSequence   uint64      `json:"stream_sequence"`
+	ConsumerSequence uint64      `json:"consumer_sequence"`
+	DeliveryCount    uint64      `json:"delivery_count"`
+	Error            string      `json:"error"`
+	Headers          nats.Header `json:"headers"`
+	BodyBase64       string      `json:"body_base64"`
+	ReceivedAt       time.Time   `json:"received_at"`
+}
+
 func (h *defaultDLQHandler) RouteToDLQ(ctx context.Context, msg *nats.Msg, cause error) error {
-	return h.routeToDLQInternal(ctx, msg, cause)
-}
-
-func (h *defaultDLQHandler) ValidateDLQ() error {
-	return h.validateDLQInternal()
-}
-
-func (h *defaultDLQHandler) routeToDLQInternal(ctx context.Context, msg *nats.Msg, cause error) error {
-	payload := map[string]any{
-		"subject":          msg.Subject,
-		"stream":           h.streamName,
-		"consumer":         h.consumerName,
-		"error":            cause.Error(),
-		"received_at":      time.Now().UTC(),
-		"body":             string(msg.Data),
-		"transport_msg_id": msg.Header.Get("Nats-Msg-Id"),
+	headers := make(nats.Header, len(msg.Header))
+	for key, values := range msg.Header {
+		headers[key] = append([]string(nil), values...)
 	}
-	// Enrich with JetStream metadata when available
+	payload := dlqPayload{
+		SchemaVersion: "v1",
+		MessageID:     msg.Header.Get("Nats-Msg-Id"),
+		Subject:       msg.Subject,
+		Stream:        h.streamName,
+		Consumer:      h.consumerName,
+		Error:         cause.Error(),
+		Headers:       headers,
+		BodyBase64:    base64.StdEncoding.EncodeToString(msg.Data),
+		ReceivedAt:    time.Now().UTC(),
+	}
 	if meta, err := msg.Metadata(); err == nil {
-		payload["nats_sequence"] = meta.Sequence.Stream
-		payload["deliveries"] = meta.NumDelivered
-	}
-	if msg.Reply != "" {
-		payload["reply"] = msg.Reply
-	}
-	if len(msg.Header) > 0 {
-		headers := make(map[string][]string, len(msg.Header))
-		for k, v := range msg.Header {
-			headers[k] = v
+		payload.StreamSequence = meta.Sequence.Stream
+		payload.ConsumerSequence = meta.Sequence.Consumer
+		payload.DeliveryCount = meta.NumDelivered
+		if payload.MessageID == "" {
+			payload.MessageID = fmt.Sprintf("%s:%d", h.streamName, meta.Sequence.Stream)
 		}
-		payload["headers"] = headers
 	}
 
 	data, err := json.Marshal(payload)
@@ -87,22 +92,5 @@ func (h *defaultDLQHandler) routeToDLQInternal(ctx context.Context, msg *nats.Ms
 	}
 
 	h.telemetry.RecordDLQMessage(ctx, h.streamName, h.consumerName)
-	return nil
-}
-
-func (h *defaultDLQHandler) validateDLQInternal() error {
-	if h.publisher == nil {
-		return fmt.Errorf("JetStream context is nil")
-	}
-
-	_, err := h.publisher.StreamNameBySubject(h.dlqSubject)
-	if err != nil {
-		return fmt.Errorf("DLQ subject %s not bound to any JetStream stream: %w", h.dlqSubject, err)
-	}
-
-	h.logger.Info("DLQ configuration validated",
-		zap.String("dlq_subject", h.dlqSubject),
-	)
-
 	return nil
 }

--- a/internal/infra/nats/dlq_test.go
+++ b/internal/infra/nats/dlq_test.go
@@ -4,9 +4,9 @@ import (
 	"caatsm/internal/infra/config"
 	"caatsm/internal/infra/telemetry"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -21,8 +21,6 @@ type mockPublisher struct {
 	publishErr     error
 	publishData    []byte
 	publishSubject string
-	streamNames    map[string]nats.StreamInfo
-	streamNameErr  error
 }
 
 func (m *mockPublisher) Publish(subj string, data []byte, opts ...nats.PubOpt) (*nats.PubAck, error) {
@@ -34,19 +32,6 @@ func (m *mockPublisher) Publish(subj string, data []byte, opts ...nats.PubOpt) (
 	return &nats.PubAck{Stream: "TEST", Sequence: 1}, nil
 }
 
-func (m *mockPublisher) StreamNameBySubject(subj string, opts ...nats.JSOpt) (string, error) {
-	if m.streamNameErr != nil {
-		return "", m.streamNameErr
-	}
-	if m.streamNames != nil {
-		if _, ok := m.streamNames[subj]; ok {
-			return "TEST_STREAM", nil
-		}
-		return "", fmt.Errorf("subject not found")
-	}
-	return "TEST_STREAM", nil
-}
-
 // mockTelemetryRecorder tracks calls for test assertions.
 type mockTelemetryRecorder struct {
 	dlqMessages        int
@@ -55,17 +40,22 @@ type mockTelemetryRecorder struct {
 
 func (m *mockTelemetryRecorder) RecordProcessingResult(ctx context.Context, status, category string, parseLatency time.Duration) {
 }
-func (m *mockTelemetryRecorder) RecordPublishFailure(ctx context.Context, category string)         {}
-func (m *mockTelemetryRecorder) RecordFailure(stage string)                                         {}
+func (m *mockTelemetryRecorder) RecordPublishFailure(ctx context.Context, category string) {}
+func (m *mockTelemetryRecorder) RecordFailure(stage string)                                {}
 func (m *mockTelemetryRecorder) RecordMessageHandled(ctx context.Context, stream, consumer, result string, elapsed time.Duration) {
 }
-func (m *mockTelemetryRecorder) RecordRetry(ctx context.Context, stream, consumer, reason string)  {}
-func (m *mockTelemetryRecorder) RecordDLQMessage(ctx context.Context, stream, consumer string)      { m.dlqMessages++ }
+func (m *mockTelemetryRecorder) RecordRetry(ctx context.Context, stream, consumer, reason string) {}
+func (m *mockTelemetryRecorder) RecordDLQMessage(ctx context.Context, stream, consumer string) {
+	m.dlqMessages++
+}
 func (m *mockTelemetryRecorder) RecordDLQPublishFailure(ctx context.Context, stream, consumer string) {
 	m.dlqPublishFailures++
 }
-func (m *mockTelemetryRecorder) RecordJSAPICall(operation string)                                   {}
-func (m *mockTelemetryRecorder) RecordAFTNValidationError(ctx context.Context, errorType string)     {}
+func (m *mockTelemetryRecorder) RecordDLQTerminalFailure(ctx context.Context, stream, consumer string) {
+}
+func (m *mockTelemetryRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string)  {}
+func (m *mockTelemetryRecorder) RecordJSAPICall(operation string)                                {}
+func (m *mockTelemetryRecorder) RecordAFTNValidationError(ctx context.Context, errorType string) {}
 
 var _ = Describe("DLQHandler", func() {
 	var (
@@ -87,30 +77,6 @@ var _ = Describe("DLQHandler", func() {
 		}
 	})
 
-	Describe("ValidateDLQ", func() {
-		It("returns error when publisher is nil", func() {
-			handler.publisher = nil
-			err := handler.ValidateDLQ()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("JetStream context is nil"))
-		})
-
-		It("returns error when subject is not bound to any stream", func() {
-			mock.streamNameErr = errors.New("no stream found")
-			err := handler.ValidateDLQ()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not bound to any JetStream stream"))
-		})
-
-		It("succeeds when subject is bound to a stream", func() {
-			mock.streamNames = map[string]nats.StreamInfo{
-				"caatsm.dlq": {},
-			}
-			err := handler.ValidateDLQ()
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
 	Describe("RouteToDLQ", func() {
 		It("publishes payload with expected fields on success", func() {
 			msg := &nats.Msg{
@@ -130,39 +96,27 @@ var _ = Describe("DLQHandler", func() {
 			Expect(payload["stream"]).To(Equal("TEST_STREAM"))
 			Expect(payload["consumer"]).To(Equal("test-consumer"))
 			Expect(payload["error"]).To(Equal("permanent error"))
-			Expect(payload["body"]).To(Equal("test message body"))
+			Expect(payload["schema_version"]).To(Equal("v1"))
+			Expect(payload["message_id"]).To(Equal("msg-123"))
+			Expect(payload["body_base64"]).To(Equal(base64.StdEncoding.EncodeToString([]byte("test message body"))))
 			Expect(payload["received_at"]).NotTo(BeNil())
-			Expect(payload["transport_msg_id"]).To(Equal("msg-123"))
 		})
 
-	It("includes headers in payload when present", func() {
-		msg := &nats.Msg{
-			Subject: "test",
-			Data:    []byte("data"),
-			Header:  nats.Header{"X-Custom": []string{"val1"}},
-		}
-		_ = handler.RouteToDLQ(context.Background(), msg, errors.New("err"))
-
-		var payload map[string]any
-		Expect(json.Unmarshal(mock.publishData, &payload)).To(Succeed())
-		headers, ok := payload["headers"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		vals, ok := headers["X-Custom"].([]any)
-		Expect(ok).To(BeTrue())
-		Expect(vals).To(ConsistOf("val1"))
-	})
-
-		It("includes reply in payload when present", func() {
+		It("includes headers in payload when present", func() {
 			msg := &nats.Msg{
 				Subject: "test",
 				Data:    []byte("data"),
-				Reply:   "reply.subject",
+				Header:  nats.Header{"X-Custom": []string{"val1"}},
 			}
 			_ = handler.RouteToDLQ(context.Background(), msg, errors.New("err"))
 
 			var payload map[string]any
 			Expect(json.Unmarshal(mock.publishData, &payload)).To(Succeed())
-			Expect(payload["reply"]).To(Equal("reply.subject"))
+			headers, ok := payload["headers"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			vals, ok := headers["X-Custom"].([]any)
+			Expect(ok).To(BeTrue())
+			Expect(vals).To(ConsistOf("val1"))
 		})
 
 		It("returns error when publish fails", func() {
@@ -239,52 +193,5 @@ var _ = Describe("Config DLQ validation", func() {
 		cfg.NATS.ConsumerRules.AckWait = 30 * time.Second
 		err := cfg.Validate()
 		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("Consumer DLQ handler initialization", func() {
-	It("creates DLQ handler when enabled and subject non-empty", func() {
-		cfg := &config.Config{
-			DLQ: config.DLQConfig{Enabled: true, Subject: "caatsm.dlq"},
-		}
-		var handler DLQHandler
-		if cfg.DLQ.Enabled && cfg.DLQ.Subject != "" {
-			handler = &defaultDLQHandler{
-				dlqSubject: cfg.DLQ.Subject,
-				logger:     zaptest.NewLogger(GinkgoT()),
-				telemetry:  telemetry.NewNoop(),
-			}
-		}
-		Expect(handler).NotTo(BeNil())
-	})
-
-	It("does not create DLQ handler when subject is empty", func() {
-		cfg := &config.Config{
-			DLQ: config.DLQConfig{Enabled: true, Subject: ""},
-		}
-		var handler DLQHandler
-		if cfg.DLQ.Enabled && cfg.DLQ.Subject != "" {
-			handler = &defaultDLQHandler{
-				dlqSubject: cfg.DLQ.Subject,
-				logger:     zaptest.NewLogger(GinkgoT()),
-				telemetry:  telemetry.NewNoop(),
-			}
-		}
-		Expect(handler).To(BeNil())
-	})
-
-	It("does not create DLQ handler when disabled", func() {
-		cfg := &config.Config{
-			DLQ: config.DLQConfig{Enabled: false, Subject: "caatsm.dlq"},
-		}
-		var handler DLQHandler
-		if cfg.DLQ.Enabled && cfg.DLQ.Subject != "" {
-			handler = &defaultDLQHandler{
-				dlqSubject: cfg.DLQ.Subject,
-				logger:     zaptest.NewLogger(GinkgoT()),
-				telemetry:  telemetry.NewNoop(),
-			}
-		}
-		Expect(handler).To(BeNil())
 	})
 })

--- a/internal/infra/nats/dlq_test.go
+++ b/internal/infra/nats/dlq_test.go
@@ -34,8 +34,10 @@ func (m *mockPublisher) Publish(subj string, data []byte, opts ...nats.PubOpt) (
 
 // mockTelemetryRecorder tracks calls for test assertions.
 type mockTelemetryRecorder struct {
-	dlqMessages        int
-	dlqPublishFailures int
+	dlqMessages         int
+	dlqPublishFailures  int
+	dlqTerminalFailures int
+	dlqDisabled         int
 }
 
 func (m *mockTelemetryRecorder) RecordProcessingResult(ctx context.Context, status, category string, parseLatency time.Duration) {
@@ -52,8 +54,11 @@ func (m *mockTelemetryRecorder) RecordDLQPublishFailure(ctx context.Context, str
 	m.dlqPublishFailures++
 }
 func (m *mockTelemetryRecorder) RecordDLQTerminalFailure(ctx context.Context, stream, consumer string) {
+	m.dlqTerminalFailures++
 }
-func (m *mockTelemetryRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string)  {}
+func (m *mockTelemetryRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string) {
+	m.dlqDisabled++
+}
 func (m *mockTelemetryRecorder) RecordJSAPICall(operation string)                                {}
 func (m *mockTelemetryRecorder) RecordAFTNValidationError(ctx context.Context, errorType string) {}
 

--- a/internal/infra/nats/utils.go
+++ b/internal/infra/nats/utils.go
@@ -1,27 +1,12 @@
 package nats
 
 import (
-	"context"
 	"errors"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/nats-io/nats.go"
 )
-
-// sleepWithContext sleeps for the specified duration, but returns early if the context is canceled.
-// Returns true if the full duration was slept, false if the context was canceled.
-func sleepWithContext(ctx context.Context, duration time.Duration) bool {
-	timer := time.NewTimer(duration)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return true
-	case <-ctx.Done():
-		return false
-	}
-}
 
 // isJetStreamResourceNotFound checks if an error indicates missing JetStream resources.
 func isJetStreamResourceNotFound(err error) bool {

--- a/internal/infra/telemetry/telemetry.go
+++ b/internal/infra/telemetry/telemetry.go
@@ -39,6 +39,8 @@ type Recorder interface {
 
 	// RecordDLQPublishFailure records a DLQ publish failure.
 	RecordDLQPublishFailure(ctx context.Context, stream, consumer string)
+	RecordDLQTerminalFailure(ctx context.Context, stream, consumer string)
+	RecordDLQDisabled(ctx context.Context, stream, consumer string)
 
 	// RecordJSAPICall records a JetStream API call.
 	RecordJSAPICall(operation string)
@@ -99,6 +101,8 @@ func (n *noopRecorder) RecordDLQMessage(ctx context.Context, stream, consumer st
 
 func (n *noopRecorder) RecordDLQPublishFailure(ctx context.Context, stream, consumer string) {
 }
+func (n *noopRecorder) RecordDLQTerminalFailure(ctx context.Context, stream, consumer string) {}
+func (n *noopRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string)        {}
 
 func (n *noopRecorder) RecordJSAPICall(operation string) {
 }
@@ -166,6 +170,16 @@ func (c *compositeRecorder) RecordDLQPublishFailure(ctx context.Context, stream,
 		r.RecordDLQPublishFailure(ctx, stream, consumer)
 	}
 }
+func (c *compositeRecorder) RecordDLQTerminalFailure(ctx context.Context, stream, consumer string) {
+	for _, r := range c.recorders {
+		r.RecordDLQTerminalFailure(ctx, stream, consumer)
+	}
+}
+func (c *compositeRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string) {
+	for _, r := range c.recorders {
+		r.RecordDLQDisabled(ctx, stream, consumer)
+	}
+}
 
 func (c *compositeRecorder) RecordJSAPICall(operation string) {
 	for _, r := range c.recorders {
@@ -219,6 +233,12 @@ func (p *promRecorder) RecordDLQMessage(ctx context.Context, stream, consumer st
 
 func (p *promRecorder) RecordDLQPublishFailure(ctx context.Context, stream, consumer string) {
 	obsmetrics.RecordDLQPublishFailure(stream, consumer)
+}
+func (p *promRecorder) RecordDLQTerminalFailure(ctx context.Context, stream, consumer string) {
+	obsmetrics.RecordDLQTerminalFailure(stream, consumer)
+}
+func (p *promRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string) {
+	obsmetrics.RecordDLQDisabled(stream, consumer)
 }
 
 func (p *promRecorder) RecordJSAPICall(operation string) {
@@ -320,6 +340,8 @@ func (o *otelRecorder) RecordDLQMessage(ctx context.Context, stream, consumer st
 func (o *otelRecorder) RecordDLQPublishFailure(ctx context.Context, stream, consumer string) {
 	// Intentionally a no-op: this metric is already exposed via the Prometheus recorder (promRecorder).
 }
+func (o *otelRecorder) RecordDLQTerminalFailure(ctx context.Context, stream, consumer string) {}
+func (o *otelRecorder) RecordDLQDisabled(ctx context.Context, stream, consumer string)        {}
 
 func (o *otelRecorder) RecordJSAPICall(operation string) {
 	// Intentionally a no-op: this metric is already exposed via the Prometheus recorder (promRecorder).
@@ -329,5 +351,3 @@ func (o *otelRecorder) RecordAFTNValidationError(ctx context.Context, errorType 
 	// AFTN validation metrics are primarily tracked via Prometheus.
 	// This is a no-op for OTEL recorder.
 }
-
-

--- a/test/integration/dlq_stream_test.go
+++ b/test/integration/dlq_stream_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	loginfra "caatsm/internal/infra/log"
+	natsinfra "caatsm/internal/infra/nats"
+	telemetryinfra "caatsm/internal/infra/telemetry"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDLQStreamIsIsolated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	natsContainer, natsURL := startNATS(ctx, t)
+	defer func() { _ = natsContainer.Terminate(context.Background()) }()
+
+	cfg := buildTestConfig(natsURL, "postgres://unused")
+	cfg.DLQ.Enabled = true
+	cfg.DLQ.Subject = "integration.dlq"
+	require.NoError(t, cfg.Validate())
+
+	logger, err := loginfra.ProvideLogger(cfg)
+	require.NoError(t, err)
+	defer logger.Sync()
+	nc, err := natsinfra.ProvideNATSConn(cfg, logger)
+	require.NoError(t, err)
+	defer nc.Close()
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+
+	_, err = natsinfra.ProvideConsumer(nc, js, nil, cfg, telemetryinfra.NewNoop(), logger)
+	require.NoError(t, err)
+
+	business, err := js.StreamInfo(cfg.NATS.Stream)
+	require.NoError(t, err)
+	dlq, err := js.StreamInfo(cfg.NATS.Stream + "_DLQ")
+	require.NoError(t, err)
+	if dlq.Config.Retention != nats.LimitsPolicy {
+		t.Fatalf("DLQ retention = %v, want LimitsPolicy", dlq.Config.Retention)
+	}
+	require.NotContains(t, business.Config.Subjects, cfg.DLQ.Subject)
+	require.Equal(t, []string{cfg.DLQ.Subject}, dlq.Config.Subjects)
+}

--- a/test/integration/jetstream_to_timescale_test.go
+++ b/test/integration/jetstream_to_timescale_test.go
@@ -12,6 +12,7 @@ import (
 
 	"caatsm/internal/adapter/dto"
 	"caatsm/internal/adapter/parser"
+	weatherparser "caatsm/internal/adapter/parser/weather"
 	"caatsm/internal/app"
 	"caatsm/internal/infra/config"
 	loginfra "caatsm/internal/infra/log"
@@ -19,6 +20,7 @@ import (
 	postgresinfra "caatsm/internal/infra/postgres"
 	telemetryinfra "caatsm/internal/infra/telemetry"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
 	tc "github.com/testcontainers/testcontainers-go"
@@ -82,7 +84,7 @@ func TestJetStreamToTimescaleFlow(t *testing.T) {
 	}
 
 	telemetryRecorder := telemetryinfra.NewNoop()
-	proc := app.NewMessageProcessor(parser.ProvideParser(), repo, publisher, telemetryRecorder, logger, cfg)
+	proc := app.NewMessageProcessor(parser.ProvideParser(weatherparser.NewWeatherParser()), repo, publisher, telemetryRecorder, logger, cfg)
 	consumer, err := natsinfra.ProvideConsumer(conn, js, proc, cfg, telemetryRecorder, logger)
 	if err != nil {
 		t.Fatalf("failed to init consumer: %v", err)

--- a/test/integration/nats_recovery_test.go
+++ b/test/integration/nats_recovery_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	loginfra "caatsm/internal/infra/log"
 	natsinfra "caatsm/internal/infra/nats"
+	telemetryinfra "caatsm/internal/infra/telemetry"
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -37,33 +39,19 @@ func TestNATSConsumerRecovery(t *testing.T) {
 	js, err := nc.JetStream()
 	require.NoError(t, err)
 
-	// Test stream recovery
-	streamManager := natsinfra.NewStreamManager(js, "TEST_STREAM", []string{"test.subject"}, nil)
-	err = streamManager.EnsureStream(nil) // nil uses default stream configuration
-	assert.NoError(t, err)
+	cfg := buildTestConfig(natsURL, "postgres://unused")
+	logger, err := loginfra.ProvideLogger(cfg)
+	require.NoError(t, err)
+	defer logger.Sync()
 
-	// Test consumer recovery
-	consumerManager := natsinfra.NewConsumerManager(js, "TEST_STREAM", "test-consumer", "test.subject", nil)
-	consumerConfig := &nats.ConsumerConfig{
-		Durable:   "test-consumer",
-		AckPolicy: nats.AckExplicitPolicy,
-	}
-	err = consumerManager.EnsureConsumer(consumerConfig)
-	assert.NoError(t, err)
+	_, err = natsinfra.ProvideConsumer(nc, js, nil, cfg, telemetryinfra.NewNoop(), logger)
+	require.NoError(t, err)
 
-	// Test pull subscription creation
-	sub, err := consumerManager.CreatePullSubscription()
-	assert.NoError(t, err)
-	sub.Unsubscribe()
-
-	// Test recovery when resources don't exist
-	// Delete the consumer and try recovery
-	err = js.DeleteConsumer("TEST_STREAM", "test-consumer")
+	err = js.DeleteConsumer(cfg.NATS.Stream, cfg.NATS.Consumer)
 	if err != nil && !errors.Is(err, nats.ErrConsumerNotFound) {
 		require.NoError(t, err)
 	}
 
-	// This should recreate the consumer
-	_, err = consumerManager.CreatePullSubscriptionWithRecovery(streamManager, consumerConfig)
+	_, err = natsinfra.ProvideConsumer(nc, js, nil, cfg, telemetryinfra.NewNoop(), logger)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- isolate DLQ traffic in a dedicated Limits-retention JetStream stream
- retain source messages when DLQ publication fails and expose terminal recovery metrics
- simplify DLQ payload/handler code and align alerts, documentation, and tests
- add consumer lifecycle coverage and restore integration-suite compatibility

## Validation
- `go test ./...`
- `make lint`
- `go test -tags=integration ./test/integration -run '^$'`

## Note
- The Docker-backed DLQ stream isolation test is ready but could not run locally because the Docker daemon is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated DLQ streams isolated from primary business streams.
  * Enhanced DLQ messages with metadata and lossless, Base64-encoded payloads.
  * Added alerts and metrics for terminal DLQ failures and disabled DLQ routing.

* **Bug Fixes**
  * Failed DLQ deliveries now retain the original message for retry or manual recovery.
  * Source messages are acknowledged only after successful DLQ publication.
  * Improved consumer cleanup and recovery during shutdown and restart.

* **Documentation**
  * Updated reliability and observability guidance for DLQ behavior, recovery, alerts, and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->